### PR TITLE
Remove unused code that was causing a crash.

### DIFF
--- a/src/ircord.nim
+++ b/src/ircord.nim
@@ -449,7 +449,6 @@ proc getDiff(oldContent, newContent: seq[string]): string =
         for slice in slices[start .. i - 1]:
           if contextLeftCnt > 2:
             break
-          let lastSlice = slice.b[min(slice.b.len - 1, 3)]
           newmsg.add slice.b.join(" ")
         newmsg.add " ... "
         if i < slices.len - 1:


### PR DESCRIPTION
The crash (out of bounds access) could be caused by removing and inserting text in a single edit. e.g.

The quick brown fox jumped over the lazy dog.
->
The brown fox jumped over the quick lazy dog.